### PR TITLE
Set max_allowed_packet in .my.cnf for big imports

### DIFF
--- a/snippets/mysql.md
+++ b/snippets/mysql.md
@@ -15,6 +15,12 @@ character-set-server=utf8
 socket          = /containers/XXXXX/db.mysql/mysqld.sock
 ```
 
+Note: if you need to import dumps with very large column values add the following line in the [mysqld] section:
+
+```ini
+max_allowed_packet = 128M
+```
+
 run
 
 ```sh


### PR DESCRIPTION
Without that option the error:
ERROR 2006 (HY000) at line 723: MySQL server has gone away
will pop up when trying to import big dumps.
