### PR TITLE
"Require all granted" doesn't work on apache 2.2

### DIFF
--- a/snippets/apache.md
+++ b/snippets/apache.md
@@ -39,6 +39,7 @@ An example mass virtualhosting configuration:
         <Directory /containers/XXXXX/www>
                 Options FollowSymLinks
                 AllowOverride All
+                # Only for apache v2.4+
                 Require all granted
         </Directory>
 


### PR DESCRIPTION
Added a comment for old distros.