### PR TITLE
Some updates on documentation for apache and mysql

### DIFF
--- a/snippets/apache.md
+++ b/snippets/apache.md
@@ -52,7 +52,7 @@ An example mass virtualhosting configuration:
 Running it
 ==========
 
-Use this vassal as your base configuration (for precise and wheezy)
+Use this vassal in ~/vassals/apache.ini as your base configuration (for precise and wheezy)
 
 ```ini
 [uwsgi]

--- a/snippets/mysql.md
+++ b/snippets/mysql.md
@@ -21,10 +21,16 @@ Note: if you need to import dumps with very large column values add the followin
 max_allowed_packet = 16M
 ```
 
-run
+For Precise and Wheezy run
 
 ```sh
 mysql_install_db --defaults-file=.my.cnf
+```
+
+or for Saucy and Trusty run
+
+```sh
+mysqld --defaults-file=~/.my.cnf --initialize --user=mysql
 ```
 
 and (for allowing transparent compatibility with debian/ubuntu mysql environment)


### PR DESCRIPTION
I've only updated a bit the docs: 

- Added specific filename for apache vassal (vassals/apache.ini), 
- I've added an example for newer distro for the mysq install command, i assumed the usual distinction for precise+wheezy / saucy+trusty, but i'm not sure if this is correct.