### PR TITLE
current containers and domains

### DIFF
--- a/uwsgi_it_api/uwsgi_it_api/tests.py
+++ b/uwsgi_it_api/uwsgi_it_api/tests.py
@@ -214,10 +214,26 @@ class ApiTest(ViewsTest):
         self.assertEqual(response.status_code, 200)
 
     def test_containers_per_domain(self):
+        yesterday = today - datetime.timedelta(1)
+        HitsDomainMetric.objects.create(
+            domain=self.domain,
+            container=self.container,
+            year=yesterday.year,
+            month=yesterday.month,
+            day=yesterday.day,
+        )
         response = self.logged_get_response_for_view('domains/1/containers', containers_per_domain, {'id': self.domain.pk})
         self.assertEqual(response.status_code, 200)
 
     def test_domains_in_container(self):
+        yesterday = today - datetime.timedelta(1)
+        HitsDomainMetric.objects.create(
+            domain=self.domain,
+            container=self.container,
+            year=yesterday.year,
+            month=yesterday.month,
+            day=yesterday.day,
+        )
         response = self.logged_get_response_for_view('container/1/domains', domains_in_container, {'id': self.container.pk})
         self.assertEqual(response.status_code, 200)
 

--- a/uwsgi_it_api/uwsgi_it_api/views.py
+++ b/uwsgi_it_api/uwsgi_it_api/views.py
@@ -950,10 +950,15 @@ def containers_per_domain(request, id):
             return HttpResponseNotFound(json.dumps({'error': 'Not found'}),
                                         content_type="application/json")
 
+        today = datetime.datetime.today()
         container_list = [{'id': c.pk, 'uuid': c.uuid, 'name': c.name, 'uid': c.uid} for c in Container.objects.filter(
             pk__in=HitsDomainMetric.objects.values_list(
-                'container', flat=True).filter(domain=domain).order_by(
-                    '-year', '-month', '-day')
+                'container', flat=True).filter(
+                domain=domain,
+                year=today.year,
+                month=today.month,
+                day=today.day
+            ).order_by('-year', '-month', '-day')
         )]
         return spit_json(request, container_list)
 
@@ -974,10 +979,15 @@ def domains_in_container(request, id):
             return HttpResponseNotFound(json.dumps({'error': 'Not found'}),
                                         content_type="application/json")
 
+        today = datetime.datetime.today()
         domain_list = [{'id': d.pk, 'uuid': d.uuid, 'name': d.name} for d in Domain.objects.filter(
             pk__in=HitsDomainMetric.objects.values_list(
-                'domain', flat=True).filter(container=container_obj).order_by(
-                    '-year', '-month', '-day')
+                'domain', flat=True).filter(
+                container=container_obj,
+                year=today.year,
+                month=today.month,
+                day=today.day
+            ).order_by('-year', '-month', '-day')
         )]
 
         return spit_json(request, domain_list)


### PR DESCRIPTION
containers_per_domain and domains_in_container api now return current containers per domain and domains in container
Until now, these apis returned also past domains linked to all containers