### PR TITLE
Missing a slash

### DIFF
--- a/snippets/staticonly.md
+++ b/snippets/staticonly.md
@@ -41,7 +41,7 @@ domain = mydomain.it
 basedir = $(HOME)/www/$(domain)
 offload-threads = 2
 route = ^/$ static:%(basedir)/index.html
-route = /(.*) static:%(basedir)$1
+route = /(.*) static:%(basedir)/$1
 ```
 
 Please note that the specific rule for */* must be placed before the


### PR DESCRIPTION
The example for the catch all rule is missing a slash. And now i miss a couple of hours of my life too!